### PR TITLE
Add container crash checker script

### DIFF
--- a/container-crash-checker.sh
+++ b/container-crash-checker.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+# Check for container crashes
+crash_files=$(cat system-logs/nomad-jobs/*.json | grep -Ril "Docker container exited with non-zero exit code: 137")
+
+# Iterate through each result
+for file in $crash_files; do
+  echo "Checking file: $file"
+  # Extract timestamp and convert to human-readable format
+  timestamp=$(cat system-logs/nomad-jobs/$file | jq | grep -B 2 137 | grep "Time" | awk '{print $2}' | tr -d ',')
+  seconds=$(echo "$timestamp / 1000000000" | bc)
+  nanoseconds=$(echo "$timestamp % 1000000000" | bc)
+  formatted_date=$(date -u -d @${seconds} +"%Y-%m-%d %H:%M:%S")
+  formatted_nanoseconds=$(printf "%03d" $((nanoseconds/1000000)))
+  human_readable_date="${formatted_date}.${formatted_nanoseconds}"
+  echo "Crash Time: $human_readable_date"
+done


### PR DESCRIPTION
Adds a new bash script named `container-crash-checker.sh` to automate the process of checking for container crashes, iterating through crash instances, and converting timestamps to human-readable format.
- **Script Functionality**: Searches for crash instances in `system-logs/nomad-jobs/*.json` files using a grep command for "Docker container exited with non-zero exit code: 137".
- **Iteration and Timestamp Conversion**: For each crash instance found, the script extracts the timestamp, converts it to a human-readable format using `date` and `bc` commands, and outputs the crash time.
- **Output**: Displays the file being checked and the corresponding crash time in a human-readable format.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/container-crash-checker?shareId=0b231365-bb20-4fd2-9fe7-0636bb078bd5).