### PR TITLE
Fix file path errors and improve grep operation in script

### DIFF
--- a/container-crash-checker.sh
+++ b/container-crash-checker.sh
@@ -1,17 +1,16 @@
 #!/bin/bash
 
-# Check for container crashes
-crash_files=$(cat system-logs/nomad-jobs/*.json | grep -Ril "Docker container exited with non-zero exit code: 137")
-
-# Iterate through each result
-for file in $crash_files; do
-  echo "Checking file: $file"
-  # Extract timestamp and convert to human-readable format
-  timestamp=$(cat system-logs/nomad-jobs/$file | jq | grep -B 2 137 | grep "Time" | awk '{print $2}' | tr -d ',')
-  seconds=$(echo "$timestamp / 1000000000" | bc)
-  nanoseconds=$(echo "$timestamp % 1000000000" | bc)
-  formatted_date=$(date -u -d @${seconds} +"%Y-%m-%d %H:%M:%S")
-  formatted_nanoseconds=$(printf "%03d" $((nanoseconds/1000000)))
-  human_readable_date="${formatted_date}.${formatted_nanoseconds}"
-  echo "Crash Time: $human_readable_date"
+# Check for container crashes and echo found files immediately
+find system-logs/nomad-jobs/ -name "*.json" | while read file; do
+  if grep -q "Docker container exited with non-zero exit code: 137" "$file"; then
+    echo "Found crash file: $file"
+    # Extract timestamp and convert to human-readable format
+    timestamp=$(jq < "$file" | grep -B 2 137 | grep "Time" | awk '{print $2}' | tr -d ',')
+    seconds=$(echo "$timestamp / 1000000000" | bc)
+    nanoseconds=$(echo "$timestamp % 1000000000" | bc)
+    formatted_date=$(date -u -d @${seconds} +"%Y-%m-%d %H:%M:%S")
+    formatted_nanoseconds=$(printf "%03d" $((nanoseconds/1000000)))
+    human_readable_date="${formatted_date}.${formatted_nanoseconds}"
+    echo "Crash Time: $human_readable_date"
+  fi
 done


### PR DESCRIPTION
Implements improvements to the `container-crash-checker.sh` script to address file path errors, syntax issues, invalid dates, and enhance user feedback during the crash file search process.

- **Fixes file path and syntax errors**: Corrects the file path in the script to prevent "No such file or directory" errors. Also, removes redundant `cat` command and fixes syntax errors to ensure accurate crash time calculation.
- **Enhances user feedback**: Modifies the script to use a `find` command combined with a `while` loop, allowing it to echo found crash files immediately. This provides real-time feedback to users, indicating the script is actively processing and finding relevant files.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/container-crash-checker?shareId=14fc23c9-042b-470f-bc07-b9d089a531f3).