### PR TITLE
Fix crash time display and include epoch time

### DIFF
--- a/container-crash-checker.sh
+++ b/container-crash-checker.sh
@@ -8,9 +8,11 @@ find system-logs/nomad-jobs/ -name "*.json" | while read file; do
     timestamp=$(jq < "$file" | grep -B 2 137 | grep "Time" | awk '{print $2}' | tr -d ',')
     seconds=$(echo "$timestamp / 1000000000" | bc)
     nanoseconds=$(echo "$timestamp % 1000000000" | bc)
-    formatted_date=$(date -u -d @${seconds} +"%Y-%m-%d %H:%M:%S")
+    # Corrected date command usage to avoid "extra operand" error
+    formatted_date=$(date -u +"%Y-%m-%d %H:%M:%S" --date="@${seconds}")
     formatted_nanoseconds=$(printf "%03d" $((nanoseconds/1000000)))
     human_readable_date="${formatted_date}.${formatted_nanoseconds}"
-    echo "Crash Time: $human_readable_date"
+    # Include epoch time in the output line
+    echo "epoch: ${timestamp}  Crash Time: $human_readable_date"
   fi
 done


### PR DESCRIPTION
Updates the `container-crash-checker.sh` script to correctly parse and display crash files with epoch time and handle date formatting without syntax errors.

- **Corrects date command usage** to avoid the "extra operand" error by specifying the format before the `--date` option.
- **Includes epoch time** in the output alongside the human-readable crash time, fulfilling the updated output requirements.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/container-crash-checker?shareId=a9ac958d-7e4b-4c7a-a342-51363af5b4a9).