### PR TITLE
Fix date parsing for crash times

### DIFF
--- a/container-crash-checker.sh
+++ b/container-crash-checker.sh
@@ -5,14 +5,16 @@ find system-logs/nomad-jobs/ -name "*.json" | while read file; do
   if grep -q "Docker container exited with non-zero exit code: 137" "$file"; then
     echo "Found crash file: $file"
     # Extract timestamp and convert to human-readable format
-    timestamp=$(jq < "$file" | grep -B 2 137 | grep "Time" | awk '{print $2}' | tr -d ',')
-    seconds=$(echo "$timestamp / 1000000000" | bc)
-    nanoseconds=$(echo "$timestamp % 1000000000" | bc)
-    # Corrected date command usage to avoid "extra operand" error
-    formatted_date=$(date -u +"%Y-%m-%d %H:%M:%S" --date="@${seconds}")
-    formatted_nanoseconds=$(printf "%03d" $((nanoseconds/1000000)))
-    human_readable_date="${formatted_date}.${formatted_nanoseconds}"
-    # Include epoch time in the output line
-    echo "epoch: ${timestamp}  Crash Time: $human_readable_date"
+    # Handle multiple lines of timestamps correctly
+    jq < "$file" | grep -B 2 137 | grep "Time" | awk '{print $2}' | tr -d ',' | while read timestamp; do
+      seconds=$(echo "$timestamp / 1000000000" | bc)
+      nanoseconds=$(echo "$timestamp % 1000000000" | bc)
+      # Process each timestamp individually
+      formatted_date=$(date -u +"%Y-%m-%d %H:%M:%S" --date="@${seconds}")
+      formatted_nanoseconds=$(printf "%03d" $((nanoseconds/1000000)))
+      human_readable_date="${formatted_date}.${formatted_nanoseconds}"
+      # Include epoch time in the output line
+      echo "epoch: ${timestamp}  Crash Time: $human_readable_date"
+    done
   fi
 done


### PR DESCRIPTION
Implements a fix in `container-crash-checker.sh` to correctly parse and display crash times for all dates without syntax errors or invalid date messages.

- **Handles multiple lines of timestamps:** Modifies the script to correctly process multiple lines of timestamps by iterating over each timestamp individually. This prevents the previous issue of concatenated timestamps leading to syntax errors.
- **Refines date command usage:** Ensures that the `date` command processes each timestamp individually, avoiding the "extra operand" error and correctly formatting the crash time in a human-readable format.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/container-crash-checker?shareId=9263f52f-4164-418e-8fd6-2b2e8d1a0822).