### PR TITLE
Extend script to check for exit codes 138 and 139

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Checking for container crashes with:
 
 ```
-cat system-logs/nomad-jobs/*.json | grep -Ril "Docker container exited with non-zero exit code: 137"
+cat system-logs/nomad-jobs/*.json | grep -Ril "Docker container exited with non-zero exit code: 137\|Docker container exited with non-zero exit code: 138\|Docker container exited with non-zero exit code: 139"
 ```
 
 From a list of container crashes:
@@ -25,16 +25,16 @@ system-logs/nomad-jobs/mps.frontend[0].json
 system-logs/nomad-jobs/mssql.mssql[0].json
 ```
 
-looking at individual instances of 137's:
+looking at individual instances of 137's, 138's, and 139's:
 
 ```
-cat system-logs/nomad-jobs/mps.frontend[0].json | jq | grep -B 2 137
+cat system-logs/nomad-jobs/mps.frontend[0].json | jq | grep -B 2 "137\|138\|139"
 ```
 
 produces output like this:
 
 ```
-[Bundle #123456] 123456 $ cat system-logs/nomad-jobs/mps.frontend[0].json | jq | grep -B 2 137
+[Bundle #123456] 123456 $ cat system-logs/nomad-jobs/mps.frontend[0].json | jq | grep -B 2 "137\|138\|139"
           "Type": "Terminated",
           "Time": 1700323960296048000,
           "Message": "Docker container exited with non-zero exit code: 137",
@@ -83,11 +83,11 @@ echo '#!/bin/bash
 
 # Check for container crashes and echo found files immediately
 find system-logs/nomad-jobs/ -name "*.json" | while read file; do
-  if grep -q "Docker container exited with non-zero exit code: 137" "$file"; then
-    echo "Found exit137 in: $file"
+  if grep -q "Docker container exited with non-zero exit code: 137\|Docker container exited with non-zero exit code: 138\|Docker container exited with non-zero exit code: 139" "$file"; then
+    echo "Found exit code 137, 138, or 139 in: $file"
     # Extract timestamp and convert to human-readable format
     # Handle multiple lines of timestamps correctly
-    jq < "$file" | grep -B 2 137 | grep "Time" | awk '{print $2}' | tr -d ',' | while read timestamp; do
+    jq < "$file" | grep -B 2 "137\|138\|139" | grep "Time" | awk '{print $2}' | tr -d ',' | while read timestamp; do
       # Ensure arithmetic operations are performed on individual lines to avoid syntax errors
       seconds=$(echo "$timestamp / 1000000000" | bc)
       nanoseconds=$(echo "$timestamp % 1000000000" | bc)
@@ -113,48 +113,47 @@ run with:
 ./ccc.sh
 ```
 
-results will tell you which files containers 137's and convert them to GMT
+results will tell you which files containers 137's, 138's, and 139's and convert them to GMT
 
 ```
 [Bundle #131491] 131491 $ ./container-crash-check.sh
-Found exit137 in: system-logs/nomad-jobs/consul-template.consul-template[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/consul-template.consul-template[0].json
 epoch: 1713989368357771500  Crash Time: 2024-04-24 20:09:28.357
-Found exit137 in: system-logs/nomad-jobs/token.backend[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/token.backend[0].json
 epoch: 1713200806591068400  Crash Time: 2024-04-15 17:06:46.591
 epoch: 1713989368407380200  Crash Time: 2024-04-24 20:09:28.407
-Found exit137 in: system-logs/nomad-jobs/token.frontend[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/token.frontend[0].json
 epoch: 1713200806804237600  Crash Time: 2024-04-15 17:06:46.804
 epoch: 1713989368157206300  Crash Time: 2024-04-24 20:09:28.157
-Found exit137 in: system-logs/nomad-jobs/mysql.mysql[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/mysql.mysql[0].json
 epoch: 1713989368740230100  Crash Time: 2024-04-24 20:09:28.740
-Found exit137 in: system-logs/nomad-jobs/babeld.babeld[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/babeld.babeld[0].json
 epoch: 1713200806985290800  Crash Time: 2024-04-15 17:06:46.985
 epoch: 1713989368339992800  Crash Time: 2024-04-24 20:09:28.339
-Found exit137 in: system-logs/nomad-jobs/pages-deployer-api.pages-deployer-api[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/pages-deployer-api.pages-deployer-api[0].json
 epoch: 1713200806884139300  Crash Time: 2024-04-15 17:06:46.884
 epoch: 1713989368323414000  Crash Time: 2024-04-24 20:09:28.323
-Found exit137 in: system-logs/nomad-jobs/pages-deployer-worker.pages-deployer-worker[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/pages-deployer-worker.pages-deployer-worker[0].json
 epoch: 1713200806575738400  Crash Time: 2024-04-15 17:06:46.575
 epoch: 1713989368314713000  Crash Time: 2024-04-24 20:09:28.314
-Found exit137 in: system-logs/nomad-jobs/artifactcache.backend[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/artifactcache.backend[0].json
 epoch: 1713200806745746000  Crash Time: 2024-04-15 17:06:46.745
 epoch: 1713989368174419700  Crash Time: 2024-04-24 20:09:28.174
-Found exit137 in: system-logs/nomad-jobs/artifactcache.frontend[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/artifactcache.frontend[0].json
 epoch: 1713200806283576600  Crash Time: 2024-04-15 17:06:46.283
 epoch: 1713989368757532000  Crash Time: 2024-04-24 20:09:28.757
-Found exit137 in: system-logs/nomad-jobs/actions.frontend[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/actions.frontend[0].json
 epoch: 1713200806270373000  Crash Time: 2024-04-15 17:06:46.270
 epoch: 1713989368917609500  Crash Time: 2024-04-24 20:09:28.917
-Found exit137 in: system-logs/nomad-jobs/mps.backend[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/mps.backend[0].json
 epoch: 1713200806654149000  Crash Time: 2024-04-15 17:06:46.654
 epoch: 1713989368466476000  Crash Time: 2024-04-24 20:09:28.466
-Found exit137 in: system-logs/nomad-jobs/actions.backend[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/actions.backend[0].json
 epoch: 1713200806680714800  Crash Time: 2024-04-15 17:06:46.680
 epoch: 1713989368235224800  Crash Time: 2024-04-24 20:09:28.235
-Found exit137 in: system-logs/nomad-jobs/mps.frontend[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/mps.frontend[0].json
 epoch: 1713200806933305900  Crash Time: 2024-04-15 17:06:46.933
 epoch: 1713989368185980000  Crash Time: 2024-04-24 20:09:28.185
-Found exit137 in: system-logs/nomad-jobs/mssql.mssql[0].json
+Found exit code 137, 138, or 139 in: system-logs/nomad-jobs/mssql.mssql[0].json
 epoch: 1713989368121627600  Crash Time: 2024-04-24 20:09:28.121
 ```
-

--- a/container-crash-checker.sh
+++ b/container-crash-checker.sh
@@ -2,11 +2,11 @@
 
 # Check for container crashes and echo found files immediately
 find system-logs/nomad-jobs/ -name "*.json" | while read file; do
-  if grep -q "Docker container exited with non-zero exit code: 137" "$file"; then
-    echo "Found exit137 in: $file"
+  if grep -q "Docker container exited with non-zero exit code: 137\|Docker container exited with non-zero exit code: 138\|Docker container exited with non-zero exit code: 139" "$file"; then
+    echo "Found exit code 137, 138, or 139 in: $file"
     # Extract timestamp and convert to human-readable format
     # Handle multiple lines of timestamps correctly
-    jq < "$file" | grep -B 2 137 | grep "Time" | awk '{print $2}' | tr -d ',' | while read timestamp; do
+    jq < "$file" | grep -E -B 2 "(137|138|139)" | grep "Time" | awk '{print $2}' | tr -d ',' | while read timestamp; do
       # Ensure arithmetic operations are performed on individual lines to avoid syntax errors
       seconds=$(echo "$timestamp / 1000000000" | bc)
       nanoseconds=$(echo "$timestamp % 1000000000" | bc)


### PR DESCRIPTION
Updates the `container-crash-checker.sh` script and `README.md` documentation to include checks for exit codes 138 and 139 alongside the existing check for exit code 137.

- Modifies the `grep` command in `container-crash-checker.sh` to search for exit codes 137, 138, and 139 within container log files.
- Updates the echo statement within the script to indicate when an exit code of 137, 138, or 139 is found.
- Adjusts the `jq` and `grep` pipeline in the script to correctly handle and display occurrences of exit codes 138 and 139.
- Updates the `README.md` documentation to mention that the script now checks for exit codes 137, 138, and 139.
- Revises example commands and outputs in the `README.md` to reflect the inclusion of exit codes 138 and 139.
- Ensures usage instructions in the `README.md` are clear with the updated script functionality.


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/michaelfdickey/container-crash-checker?shareId=6eca8cf7-5507-47de-a37e-bd96a4120450).